### PR TITLE
Update Install.php

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -19,8 +19,8 @@ class Install extends Migration
                 'startAt' => $this->dateTime()->null(),
                 'endAt' => $this->dateTime()->null(),
                 'enabled' => $this->boolean()->defaultValue(false),
-                'dateCreated' => $this->timestamp(),
-                'dateUpdated' => $this->timestamp()
+                'dateCreated' => $this->dateTime(),
+                'dateUpdated' => $this->dateTime()
             ]);
         }
 
@@ -32,8 +32,8 @@ class Install extends Migration
                 'handle' => $this->string()->notNull(), // Used as template name
                 'description' => $this->string()->null(),
                 'weight' => $this->smallInteger()->notNull(), // in percents
-                'dateCreated' => $this->timestamp(),
-                'dateUpdated' => $this->timestamp()
+                'dateCreated' => $this->dateTime(),
+                'dateUpdated' => $this->dateTime()
             ]);
         }
     }


### PR DESCRIPTION
replace 'dateUpdated' => $this->timestamp(0),
with 'dateUpdated' => $this->dateTime(),

ChatGPT said:

Looking at the SQL statement, it seems that the 'dateUpdated' column is defined with a default value of timestamp(0). However, MySQL 5.7 doesn't support fractional seconds precision in the TIMESTAMP data type, and that's likely causing the error.

To fix this issue, you can modify the migration file for the Optimum plugin. Locate the file Install.php inside the matfish\Optimum\migrations directory.

Open the Install.php file and find the section where the 'dateUpdated' column is defined. Change the data type and default value for 'dateUpdated' to use the appropriate syntax for MySQL 5.7:

Replace this line:

php
Copy code
'dateUpdated' => $this->timestamp(0),
with:

php
Copy code
'dateUpdated' => $this->dateTime(),
This change ensures that the 'dateUpdated' column is defined as a DATETIME column without fractional seconds precision.